### PR TITLE
fix add domains to organization

### DIFF
--- a/web/targetApp/views.py
+++ b/web/targetApp/views.py
@@ -123,7 +123,8 @@ def add_target(request, slug):
 
                             if organization_name:
                                 organization = None
-                                if Organization.objects.filter(name=organization_name).exists():
+                                organization_query = Organization.objects.filter(name=organization_name)
+                                if organization_query.exists():
                                     organization = organization_query[0]
                                 else:
                                     organization = Organization.objects.create(


### PR DESCRIPTION
The problem detected is that when adding the domains and adding them to an organization that has not yet been created, the following error message “Exception when adding domain: local variable ‘organization_query’ referenced before the assignment”, is modified and the missing variable is added.